### PR TITLE
Customize Topics via Env Var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 APP_ENV="development"
 STORAGE_ENV="local"
 BATCH_SIZE=200
+TOPICS="basketball, soccer, volleyball"
 
 #
 # GOOGLE APIs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,10 @@ pip install -r requirements.txt # (first time only)
 
 Create a ".env" file and set your environment variables there. See the ".env.example" file and instructions below for more details.
 
+### Custom Topics
+
+Set the `TOPICS` environment variable to customize the list of tweet keywords to filter.
+
 ### Google API Credentials
 
 To store tweets to a local CSV file, skip this section. Otherwise, to store tweets in Google Big Query, set the `STORAGE_ENV` environment variable to "remote" and continue...

--- a/app/tweet_collector.py
+++ b/app/tweet_collector.py
@@ -2,6 +2,7 @@ import os
 from pprint import pprint
 from time import sleep
 
+from dotenv import load_dotenv
 from tweepy.streaming import StreamListener
 from tweepy import Stream
 from urllib3.exceptions import ProtocolError
@@ -11,12 +12,18 @@ from app.twitter_service import twitter_api
 from app.notification_service import send_email
 from app.storage_service import append_to_csv, BigQueryService
 
-TOPICS_LIST = ["impeach", "impeachment"] # todo: dynamically compile list from comma-separated env var string like "topic1,topic2"
-# NOTE: "impeachment" keywords don't trigger the "impeach" filter, so adding "impeachment" as well
-#TOPICS_LIST = ["impeach -filter:retweets"] # doesn't work
+load_dotenv()
 
 BATCH_SIZE = int(os.getenv("BATCH_SIZE", default="20")) # coerces to int
 WILL_NOTIFY = (os.getenv("WILL_NOTIFY", default="False") == "True") # coerces to bool
+
+#TOPICS_LIST = ["impeach", "impeachment"] # todo: dynamically compile list from comma-separated env var string like "topic1,topic2"
+# NOTE: "impeachment" keywords don't trigger the "impeach" filter, so adding "impeachment" as well
+#TOPICS_LIST = ["impeach -filter:retweets"] # doesn't work
+TOPICS = os.getenv("TOPICS", default="impeach, impeached, impeachment, #TrumpImpeachment, #ImpeachAndConvict, #ImpeachAndConvictTrump, #IGReport")
+
+def topics_list(topics_csv_str=TOPICS):
+    return [topic.strip() for topic in topics_csv_str.split(",")]
 
 def is_collectable(status):
     return (status.lang == "en"
@@ -181,12 +188,13 @@ if __name__ == "__main__":
     stream = Stream(listener.auth, listener)
     print("STREAM", type(stream))
 
-    print("TOPICS:", TOPICS_LIST)
-    #stream.filter(track=TOPICS_LIST)
+    topics = topics_list()
+    print("TOPICS:", topics)
+    #stream.filter(track=topics)
     # handle ProtocolErrors...
     while True:
         try:
-            stream.filter(track=TOPICS_LIST)
+            stream.filter(track=topics)
         except ProtocolError:
             print("--------------------------------")
             print("RESTARTING AFTER PROTOCOL ERROR!")

--- a/app/tweet_collector.py
+++ b/app/tweet_collector.py
@@ -14,13 +14,13 @@ from app.storage_service import append_to_csv, BigQueryService
 
 load_dotenv()
 
-BATCH_SIZE = int(os.getenv("BATCH_SIZE", default="20")) # coerces to int
-WILL_NOTIFY = (os.getenv("WILL_NOTIFY", default="False") == "True") # coerces to bool
-
 #TOPICS_LIST = ["impeach", "impeachment"] # todo: dynamically compile list from comma-separated env var string like "topic1,topic2"
 # NOTE: "impeachment" keywords don't trigger the "impeach" filter, so adding "impeachment" as well
 #TOPICS_LIST = ["impeach -filter:retweets"] # doesn't work
-TOPICS = os.getenv("TOPICS", default="impeach, impeached, impeachment, #TrumpImpeachment, #ImpeachAndConvict, #ImpeachAndConvictTrump, #IGReport")
+TOPICS = os.getenv("TOPICS", default="impeach, impeached, impeachment, #TrumpImpeachment, #ImpeachAndConvict, #ImpeachAndConvictTrump, #IGReport, #SenateHearing, #IGHearing")
+
+BATCH_SIZE = int(os.getenv("BATCH_SIZE", default="20")) # coerces to int
+WILL_NOTIFY = (os.getenv("WILL_NOTIFY", default="False") == "True") # coerces to bool
 
 def topics_list(topics_csv_str=TOPICS):
     return [topic.strip() for topic in topics_csv_str.split(",")]


### PR DESCRIPTION
Enables customization of tweet keyword topics via environment variable.

```sh
TOPICS="impeach, impeached, impeachment, #TrumpImpeachment, #ImpeachAndConvict, #ImpeachAndConvictTrump, #IGReport, #SenateHearing, #IGHearing"

TOPICS="basketball, volleyball"
```

In the future, it would be nice to keep the topics in a BigQuery table and have the collector respond to tweets from admins with content like "@ImpeachmentTrak add topic #ImpeachAndConvict" and this will ensure the given topic is in the table, and then restart the collection with a new set of topics to collect.