### PR TITLE
Devops

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,7 @@ Run the tweet collector:
 python -m app.tweet_collector
 
 # BATCH_SIZE=200 STORAGE_ENV="remote" python -m app.tweet_collector
+# APP_ENV="production" STORAGE_ENV="remote" WILL_NOTIFY=True python -m app.tweet_collector
 ```
 
 ## Testing

--- a/app/tweet_collector.py
+++ b/app/tweet_collector.py
@@ -15,7 +15,8 @@ TOPICS_LIST = ["impeach", "impeachment"] # todo: dynamically compile list from c
 # NOTE: "impeachment" keywords don't trigger the "impeach" filter, so adding "impeachment" as well
 #TOPICS_LIST = ["impeach -filter:retweets"] # doesn't work
 
-BATCH_SIZE = int(os.getenv("BATCH_SIZE", default="20"))
+BATCH_SIZE = int(os.getenv("BATCH_SIZE", default="20")) # coerces to int
+WILL_NOTIFY = (os.getenv("WILL_NOTIFY", default="False") == "True") # coerces to bool
 
 def is_collectable(status):
     return (status.lang == "en"
@@ -83,13 +84,14 @@ def backoff_strategy(i):
 
 class TweetCollector(StreamListener):
 
-    def __init__(self, batch_size=BATCH_SIZE):
+    def __init__(self, batch_size=BATCH_SIZE, will_notify=WILL_NOTIFY):
         self.api = twitter_api()
         self.auth = self.api.auth
         self.counter = 0
         self.bq_service = BigQueryService()
         self.batch_size = batch_size
         self.batch = []
+        self.will_notify = (will_notify == True)
 
     def collect(self, tweet):
         """
@@ -122,6 +124,7 @@ class TweetCollector(StreamListener):
 
     def on_connect(self):
         print("LISTENER IS CONNECTED!")
+        print("LISTENER WILL NOTIFY:", self.will_notify)
 
     def on_exception(self, exception):
         # has encountered errors:
@@ -129,38 +132,44 @@ class TweetCollector(StreamListener):
         #  + urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool
         print("EXCEPTION:", type(exception))
         print(exception)
-        #contents = f"{type(exception)}<br>{exception}"
-        #send_email(subject="Tweet Collection - Exception", contents=contents)
+        if self.will_notify:
+            contents = f"{type(exception)}<br>{exception}"
+            send_email(subject="Tweet Collection - Exception", contents=contents)
 
     def on_error(self, status_code):
         print("ERROR:", status_code)
-        #contents = f"{type(status_code)}<br>{status_code}"
-        #send_email(subject="Tweet Collection - Error", contents=contents)
+        if self.will_notify:
+            contents = f"{type(status_code)}<br>{status_code}"
+            send_email(subject="Tweet Collection - Error", contents=contents)
 
     def on_limit(self, track):
         """Param: track (int) starts low and subsequently increases"""
         print("RATE LIMITING", track)
-        #contents = f"{type(track)}<br>{track}"
-        #send_email(subject="Tweet Collection - Rate Limit", contents=contents)
+        if self.will_notify:
+            contents = f"{type(track)}<br>{track}"
+            send_email(subject="Tweet Collection - Rate Limit", contents=contents)
         sleep_seconds = backoff_strategy(track)
         print("SLEEPING FOR:", sleep_seconds, "SECONDS...")
         sleep(sleep_seconds)
 
     def on_timeout(self):
         print("TIMEOUT!")
-        #send_email(subject="Tweet Collection - Timeout", contents="Restarting...")
+        if self.will_notify:
+            send_email(subject="Tweet Collection - Timeout", contents="Restarting...")
         return True # don't kill the stream! TODO: implement back-off
 
     def on_warning(self, notice):
         print("DISCONNECTION WARNING:", type(notice))
         print(notice)
-        #contents = f"{type(notice)}<br>{notice}"
-        #send_email(subject="Tweet Collection - Disconnect Warning", contents=contents)
+        if self.will_notify:
+            contents = f"{type(notice)}<br>{notice}"
+            send_email(subject="Tweet Collection - Disconnect Warning", contents=contents)
 
     def on_disconnect(self, notice):
         print("DISCONNECT:", type(notice))
-        #contents = f"{type(notice)}<br>{notice}"
-        #send_email(subject="Tweet Collection - Disconnect", contents=contents)
+        if self.will_notify:
+            contents = f"{type(notice)}<br>{notice}"
+            send_email(subject="Tweet Collection - Disconnect", contents=contents)
 
 if __name__ == "__main__":
 

--- a/app/tweet_collector.py
+++ b/app/tweet_collector.py
@@ -1,5 +1,6 @@
 import os
 from pprint import pprint
+from time import sleep
 
 from tweepy.streaming import StreamListener
 from tweepy import Stream
@@ -121,35 +122,39 @@ class TweetCollector(StreamListener):
         #  + urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool
         print("EXCEPTION:", type(exception))
         print(exception)
-        contents = f"{type(exception)}<br>{exception}"
-        send_email(subject="Tweet Collection - Exception", contents=contents)
+        #contents = f"{type(exception)}<br>{exception}"
+        #send_email(subject="Tweet Collection - Exception", contents=contents)
 
     def on_error(self, status_code):
         print("ERROR:", status_code)
-        contents = f"{type(status_code)}<br>{status_code}"
-        send_email(subject="Tweet Collection - Error", contents=contents)
+        #contents = f"{type(status_code)}<br>{status_code}"
+        #send_email(subject="Tweet Collection - Error", contents=contents)
 
     def on_limit(self, track):
+        """Param: track (int) starts low and then gets exponentially higher (max observed is 506)"""
         print("RATE LIMITING", type(track))
         print(track)
-        contents = f"{type(track)}<br>{track}"
-        send_email(subject="Tweet Collection - Rate Limit", contents=contents)
+        #contents = f"{type(track)}<br>{track}"
+        #send_email(subject="Tweet Collection - Rate Limit", contents=contents)
+        sleep_seconds = (int(track) + 1) ** 2 # raise to the power of two
+        print("SLEEPING FOR:", sleep_seconds, "SECONDS...")
+        sleep(sleep_seconds)
 
     def on_timeout(self):
         print("TIMEOUT!")
-        send_email(subject="Tweet Collection - Timeout", contents="Restarting...")
+        #send_email(subject="Tweet Collection - Timeout", contents="Restarting...")
         return True # don't kill the stream! TODO: implement back-off
 
     def on_warning(self, notice):
         print("DISCONNECTION WARNING:", type(notice))
         print(notice)
-        contents = f"{type(notice)}<br>{notice}"
-        send_email(subject="Tweet Collection - Disconnect Warning", contents=contents)
+        #contents = f"{type(notice)}<br>{notice}"
+        #send_email(subject="Tweet Collection - Disconnect Warning", contents=contents)
 
     def on_disconnect(self, notice):
         print("DISCONNECT:", type(notice))
-        contents = f"{type(notice)}<br>{notice}"
-        send_email(subject="Tweet Collection - Disconnect", contents=contents)
+        #contents = f"{type(notice)}<br>{notice}"
+        #send_email(subject="Tweet Collection - Disconnect", contents=contents)
 
 if __name__ == "__main__":
 

--- a/app/tweet_collector.py
+++ b/app/tweet_collector.py
@@ -74,6 +74,13 @@ def parse_status(status):
     }
     return tweet
 
+def backoff_strategy(i):
+    """
+    Param: i (int) increasing rate limit number from the twitter api
+    Returns: number of seconds to sleep for
+    """
+    return (int(i) + 1) ** 2 # raise to the power of two
+
 class TweetCollector(StreamListener):
 
     def __init__(self, batch_size=BATCH_SIZE):
@@ -131,12 +138,11 @@ class TweetCollector(StreamListener):
         #send_email(subject="Tweet Collection - Error", contents=contents)
 
     def on_limit(self, track):
-        """Param: track (int) starts low and then gets exponentially higher (max observed is 506)"""
-        print("RATE LIMITING", type(track))
-        print(track)
+        """Param: track (int) starts low and subsequently increases"""
+        print("RATE LIMITING", track)
         #contents = f"{type(track)}<br>{track}"
         #send_email(subject="Tweet Collection - Rate Limit", contents=contents)
-        sleep_seconds = (int(track) + 1) ** 2 # raise to the power of two
+        sleep_seconds = backoff_strategy(track)
         print("SLEEPING FOR:", sleep_seconds, "SECONDS...")
         sleep(sleep_seconds)
 

--- a/app/twitter_service.py
+++ b/app/twitter_service.py
@@ -13,8 +13,8 @@ ACCESS_SECRET = os.getenv("TWITTER_ACCESS_TOKEN_SECRET", default="OOPS")
 def twitter_api():
     auth = tweepy.OAuthHandler(CONSUMER_KEY, CONSUMER_SECRET)
     auth.set_access_token(ACCESS_KEY, ACCESS_SECRET)
-    api = tweepy.API(auth, wait_on_rate_limit=True)
-    return api # consider returning the auth as well
+    api = tweepy.API(auth, wait_on_rate_limit=True, wait_on_rate_limit_notify=True)
+    return api
 
 if __name__ == "__main__":
     api = twitter_api()

--- a/app/twitter_service.py
+++ b/app/twitter_service.py
@@ -13,7 +13,7 @@ ACCESS_SECRET = os.getenv("TWITTER_ACCESS_TOKEN_SECRET", default="OOPS")
 def twitter_api():
     auth = tweepy.OAuthHandler(CONSUMER_KEY, CONSUMER_SECRET)
     auth.set_access_token(ACCESS_KEY, ACCESS_SECRET)
-    api = tweepy.API(auth)
+    api = tweepy.API(auth, wait_on_rate_limit=True)
     return api # consider returning the auth as well
 
 if __name__ == "__main__":

--- a/test/tweet_collector_test.py
+++ b/test/tweet_collector_test.py
@@ -1,7 +1,7 @@
 from pprint import pprint
 
 from app.tweet_collector import (TweetCollector,
-    is_collectable, parse_status, parse_full_text, parse_timestamp
+    is_collectable, parse_status, parse_full_text, parse_timestamp, backoff_strategy
 )
 
 def test_get_status(my_status, rr_status):
@@ -61,3 +61,7 @@ def test_parse_status(my_status, rr_status):
 def test_parse_timestamp(my_status):
     # BQ says... Required format is YYYY-MM-DD HH:MM[:SS[.SSSSSS]];
     assert parse_timestamp(my_status) == "2019-12-02 04:29:13"
+
+def test_backoff_strategy():
+    assert backoff_strategy(2) == 9
+    assert backoff_strategy(7) == 64


### PR DESCRIPTION
Addressing issues observed in production:
  + First, sent too many emails, and sendgrid api is now throwing unauthorized because quota is exceeded. So turn off email notifications until later resolution. Can always check the logs, so loss of email not critical. When ready to turn emails back on, set `WILL_NOTIFY=True`.
  + Second, implements back-off strategy for handling rate limit warnings.